### PR TITLE
Tiled: Support for isometric Tiled maps

### DIFF
--- a/tiled/tiled.js
+++ b/tiled/tiled.js
@@ -128,6 +128,13 @@ game.createClass('TileMap', {
         }
     },
 
+    /**
+        Get the screen position for a specific coordinate, this is dependent on the type of map
+        @method getPosition
+        @param {Number} x
+        @param {Number} y
+        @return {Object} Object with x and y screen coords
+    **/
     getPosition: function (x, y) {
         var tileWidth = this.tileWidth;
         var tileHeight = this.tileHeight;

--- a/tiled/tiled.js
+++ b/tiled/tiled.js
@@ -139,13 +139,13 @@ game.createClass('TileMap', {
         var tileWidth = this.tileWidth;
         var tileHeight = this.tileHeight;
 
-        if (this.orientation == 'orthogonal') {
+        if (this.orientation === 'orthogonal') {
             return {
                 x: x * tileWidth,
                 y: y * tileHeight,
             };
         }
-        else if (this.orientation == 'isometric') {
+        else if (this.orientation === 'isometric') {
             return {
                 x: (x - y) * (tileWidth / 2),
                 y: (x + y) * (tileHeight / 2)
@@ -206,7 +206,7 @@ game.createClass('TileMap', {
     **/
     getLayerMatrix: function (layerName) {
         var layer = this.getLayer(layerName);
-        var colCount  = layer.width;
+        var colCount = layer.width;
         var rowCount = Math.ceil(layer.data.length / colCount);
         var matrix = [];
         var i = 0;


### PR DESCRIPTION
This update makes it possible to use isometric Tiled maps while maintaining the regular orthogonal map support. Only staggered support is now missing, might add this functionality later on. 

See test image for visual representation of this update.
![screen shot 2015-03-11 at 9 14 29 pm](https://cloud.githubusercontent.com/assets/503360/6605949/476602a4-c834-11e4-92fb-a2a534df6abe.png)
