### PR TITLE
Solve a bug when removing body from world.

### DIFF
--- a/p2/p2.js
+++ b/p2/p2.js
@@ -13327,9 +13327,12 @@ game.DebugDraw.inject({
             }
 
             body.rotation = body.target.angle;
-            body.position.x = body.target.position[0] * body.target.world.ratio + body.stage.position.x;
-            body.position.y = body.target.position[1] * body.target.world.ratio + body.stage.position.y;
             if (!body.target.world) this.bodyContainer.removeChild(body);
+            else
+            {
+                body.position.x = body.target.position[0] * body.target.world.ratio + body.stage.position.x;
+                body.position.y = body.target.position[1] * body.target.world.ratio + body.stage.position.y;
+            }
         }
     }
 });


### PR DESCRIPTION
If the body were removed from the world, 'body.target.world' becomes null, and one cannot call 'body.target.world.ratio' to move the body sprite.